### PR TITLE
fix: parse sale items when viewing invoice

### DIFF
--- a/client/src/pages/sales.tsx
+++ b/client/src/pages/sales.tsx
@@ -116,20 +116,20 @@ export default function SalesPage() {
 const handleViewInvoice = async (sale: SaleWithItems) => {
   try {
     console.log("Loading items for sale:", sale.id);
-    
+
     // Cargar items desde la API
-    const items = await apiRequest("GET", `/api/sales/${sale.id}/items`);
+    const res = await apiRequest("GET", `/api/sales/${sale.id}/items`);
+    const items: SaleItem[] = await res.json();
     console.log("Loaded items from API:", items);
-    
+
     // Crear objeto de venta con items
     const saleWithItems: SaleWithItems = {
       ...sale,
-      items: items
+      items,
     };
-    
+
     setSaleForInvoice(saleWithItems);
     setInvoiceDialogOpen(true);
-    
   } catch (error) {
     console.error("Error loading sale items:", error);
     toast({


### PR DESCRIPTION
## Summary
- parse invoice items response as JSON before opening modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: use-quote-date-validation.ts parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b473b202c88327a7acd8471bf1a4ed